### PR TITLE
json_resp pour array vide []

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@
 
 **Nouveautés**
 
+* Modification de json_resp pour les retours de tableau vide
 * Ajout des ``GenericTable`` et ``GenericQuery`` (en version simplifiée sans la gestion des géométries)
 * Ajout des exceptions GeonatureApiError
 * Ajout d'une methode from_dict

--- a/src/utils_flask_sqla/response.py
+++ b/src/utils_flask_sqla/response.py
@@ -27,7 +27,7 @@ def json_resp(fn):
 def to_json_resp(
     res, status=200, filename=None, as_file=False, indent=None, extension="json"
 ):
-    if not res:
+    if not res and res != []:
         status = 404
         res = {"message": "not found"}
 


### PR DESCRIPTION
La fonction to_json_resp produit une erreur 404 si l'on renvoie un tableau vide (du fait du test 'if not res'). Dans certains il peut être interessant de savoir que la donnée recherchée est un tableau vide (pas d'observation pour une visite pour un protocole de suivi par exemple). Je propose une modification pour pouvoir renvoyer les tableau vide sans erreurs.