### PR TITLE
Json resp

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@
 
 **Nouveautés**
 
+* Modification de json_resp pour les retours de tableau vide
 * Ajout des ``GenericTable`` et ``GenericQuery`` (en version simplifiée sans la gestion des géométries)
 * Ajout des exceptions GeonatureApiError
 * Ajout d'une methode from_dict

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,7 +3,7 @@
 
 **Nouveautés**
 
-* Modification de json_resp pour les retours de tableau vide
+* Ajout de json_reps_accept pour definir les reponse qui ne renvoient pas un code erreur, ne modifie pas json_resp
 * Ajout des ``GenericTable`` et ``GenericQuery`` (en version simplifiée sans la gestion des géométries)
 * Ajout des exceptions GeonatureApiError
 * Ajout d'une methode from_dict

--- a/src/utils_flask_sqla/response.py
+++ b/src/utils_flask_sqla/response.py
@@ -27,7 +27,7 @@ def json_resp(fn):
 def to_json_resp(
     res, status=200, filename=None, as_file=False, indent=None, extension="json"
 ):
-    if not res:
+    if not res and res != []:
         status = 404
         res = {"message": "not found"}
 

--- a/src/utils_flask_sqla/response.py
+++ b/src/utils_flask_sqla/response.py
@@ -17,19 +17,20 @@ def json_resp_accept(accepted_list=[]):
         def _json_resp(*args, **kwargs):
             res = fn(*args, **kwargs)
             if isinstance(res, tuple):
-                res['accepted_list'] = accepted_list
-                return to_json_resp(*res)
+                return to_json_resp(*res, accepted_list=accepted_list)
             else:
-                return to_json_resp(res, accepted_list)
+                return to_json_resp(res, accepted_list=accepted_list)
 
         return _json_resp
     return json_resp
 
+
 json_resp = json_resp_accept()
 json_resp_accept_empty_list = json_resp_accept([[]])
 
+
 def to_json_resp(
-    res, status=200, filename=None, as_file=False, indent=None, extension="json", accepted_list = False
+    res, status=200, filename=None, as_file=False, indent=None, extension="json", accepted_list=[]
 ):
     if not ( res or res in accepted_list ) :
         status = 404

--- a/src/utils_flask_sqla/response.py
+++ b/src/utils_flask_sqla/response.py
@@ -6,28 +6,32 @@ from functools import wraps
 from flask import Response
 from werkzeug.datastructures import Headers
 
+def json_resp_accept(accepted_list=[]):
+    def json_resp(fn):
+        """
+        Décorateur transformant le résultat renvoyé par une vue
+        en objet JSON
+        """
 
-def json_resp(fn):
-    """
-    Décorateur transformant le résultat renvoyé par une vue
-    en objet JSON
-    """
+        @wraps(fn)
+        def _json_resp(*args, **kwargs):
+            res = fn(*args, **kwargs)
+            if isinstance(res, tuple):
+                res['accepted_list'] = accepted_list
+                return to_json_resp(*res)
+            else:
+                return to_json_resp(res, accepted_list)
 
-    @wraps(fn)
-    def _json_resp(*args, **kwargs):
-        res = fn(*args, **kwargs)
-        if isinstance(res, tuple):
-            return to_json_resp(*res)
-        else:
-            return to_json_resp(res)
+        return _json_resp
+    return json_resp
 
-    return _json_resp
-
+json_resp = json_resp_accept()
+json_resp_accept_empty_list = json_resp_accept([[]])
 
 def to_json_resp(
-    res, status=200, filename=None, as_file=False, indent=None, extension="json"
+    res, status=200, filename=None, as_file=False, indent=None, extension="json", accepted_list = False
 ):
-    if not res and res != []:
+    if not ( res or res in accepted_list ) :
         status = 404
         res = {"message": "not found"}
 


### PR DESCRIPTION
création d'une fonction json_resp accept avec paramètre pour pouvoir creér des décorateurs de route pour renvoyer des object json qui acceptent les object vides  (en particulier les tableaux vide) et ne déclenche pas d'erreur 404

ne modifie pas l'utilisation classique du décorateur json_resp

definition d'un decorateur json_resp_accept_empty_list qui accepte les listes vides