### PR TITLE
Trim unicode

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@
 **Nouveautés**
 
 
-* Trim sur les typed de champs character varying à longueur déterminée
+* Trim sur les typed de champs de type character
 * Ajout de json_reps_accept pour definir les reponse qui ne renvoient pas un code erreur, ne modifie pas json_resp
 * Ajout des ``GenericTable`` et ``GenericQuery`` (en version simplifiée sans la gestion des géométries)
 * Ajout de l'instance sqlalchemy (DB) en paramètre de GenericQuery

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@
 
 **Nouveautés**
 
+* Trim sur les typed de champs character varying à longueur déterminée
 * Ajout des ``GenericTable`` et ``GenericQuery`` (en version simplifiée sans la gestion des géométries)
 * Ajout de l'instance sqlalchemy (DB) en paramètre de GenericQuery
 * Ajout des exceptions GeonatureApiError

--- a/src/utils_flask_sqla/serializers.py
+++ b/src/utils_flask_sqla/serializers.py
@@ -2,6 +2,7 @@
   Serialize function for SQLAlchemy models
 """
 from sqlalchemy.orm import ColumnProperty
+from uuid import UUID
 """
     List of data type who need a particular serialization
     @TODO MISSING FLOAT
@@ -14,6 +15,7 @@ SERIALIZERS = {
     "timestamp": lambda x: str(x) if x else None,
     "uuid": lambda x: str(x) if x else None,
     "numeric": lambda x: str(x) if x else None,
+    "integer": lambda x: str(x) if isinstance(x, UUID) else x
 }
 
 

--- a/src/utils_flask_sqla/serializers.py
+++ b/src/utils_flask_sqla/serializers.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import ColumnProperty
     @TODO MISSING FLOAT
 """
 SERIALIZERS = {
+    "unicode": lambda x: x.strip() if x else None,
     "date": lambda x: str(x) if x else None,
     "datetime": lambda x: str(x) if x else None,
     "time": lambda x: str(x) if x else None,

--- a/src/utils_flask_sqla/serializers.py
+++ b/src/utils_flask_sqla/serializers.py
@@ -8,7 +8,6 @@ from uuid import UUID
     @TODO MISSING FLOAT
 """
 SERIALIZERS = {
-    "unicode": lambda x: x.strip() if x else None,
     "date": lambda x: str(x) if x else None,
     "datetime": lambda x: str(x) if x else None,
     "time": lambda x: str(x) if x else None,


### PR DESCRIPTION
Ajout d'un serilialzer pour le type unicode
pour le cas des champs de type character à longueur déterminée
le serialiser renvoie x.strip() pour couper la partie remplie avec des espaces à droite

par exemple pour la table gn_commons.t_modules et le champs module_path de type character(255)
on a une chaine de 255 caractère 'admin           ...   ' avec la modification on aura seulement 'admin'
