### PR TITLE
fix serialize unicode as integer

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@
 * Ajout de l'instance sqlalchemy (DB) en paramètre de GenericQuery
 * Ajout des exceptions GeonatureApiError
 * Ajout d'une methode from_dict
+* gestion des uuid qui arrivent comme des integer dans les fonctions de sérialisation
 
 0.0.1 (2019-10-17)
 ------------------

--- a/src/utils_flask_sqla/serializers.py
+++ b/src/utils_flask_sqla/serializers.py
@@ -2,6 +2,7 @@
   Serialize function for SQLAlchemy models
 """
 from sqlalchemy.orm import ColumnProperty
+from uuid import UUID
 """
     List of data type who need a particular serialization
     @TODO MISSING FLOAT
@@ -13,6 +14,7 @@ SERIALIZERS = {
     "timestamp": lambda x: str(x) if x else None,
     "uuid": lambda x: str(x) if x else None,
     "numeric": lambda x: str(x) if x else None,
+    "integer": lambda x: str(x) if isinstance(x, UUID) else x
 }
 
 


### PR DESCRIPTION
modification  pour gérer le cas où des uuid sont sérialisés comme des entier
dans ce cas , on les transforme en chaîne de caractère