### PR TITLE
niveau_recursivite

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@
 * Ajout de l'instance sqlalchemy (DB) en paramètre de GenericQuery
 * Ajout des exceptions GeonatureApiError
 * Ajout d'une methode from_dict
+* Modification de as_dict : le parametre recursif peut etre entier et precise le niveau de recursivite
 
 0.0.1 (2019-10-17)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,7 @@
 * Ajout de l'instance sqlalchemy (DB) en paramètre de GenericQuery
 * Ajout des exceptions GeonatureApiError
 * Ajout d'une methode from_dict
-* Modification de as_dict : le parametre recursif peut etre entier et precise le niveau de recursivite
+* Modification de as_dict : ajout d'un parametre depth pour definir le niveau de récursivité
 
 0.0.1 (2019-10-17)
 ------------------

--- a/src/utils_flask_sqla/serializers.py
+++ b/src/utils_flask_sqla/serializers.py
@@ -2,6 +2,7 @@
   Serialize function for SQLAlchemy models
 """
 from sqlalchemy.orm import ColumnProperty
+import inspect
 """
     List of data type who need a particular serialization
     @TODO MISSING FLOAT
@@ -71,36 +72,32 @@ def serializable(cls):
         (db_rel.key, db_rel.uselist) for db_rel in cls.__mapper__.relationships
     ]
 
-    def serializefn(self, recursif=False, columns=(), relationships=()):
+    def serializefn(self, recursif=False, columns=(), relationships=(), depth=None):
         """
         Méthode qui renvoie les données de l'objet sous la forme d'un dict
 
         Parameters
         ----------
-            recursif: boolean ou entier
-                si boolean:
+            recursif: boolean
                     Spécifie si on veut que les sous-objets (relationship)
-                    soit également sérialisé
-                si entier niveau de récursion:
+            depth: entier
+                spécifie le niveau de niveau de récursion:
                     0 juste l'objet
                     1 l'objet et ses sous-objets
                     2 ...
+                si depth est spécifié :
+                    recursif prend la valeur True
+                si depth n'est pas spécifié et recursif est à True :
+                    il n'y a pas de limite à la récursivité
             columns: liste
                 liste des colonnes qui doivent être prises en compte
             relationships: liste
                 liste des relationships qui doivent être prise en compte
         """
 
-        # si recursif est un entier
-        #
-        is_integer = not isinstance(recursif, bool) and isinstance(recursif, int)
-
-        if is_integer:
-            if recursif < 0:
-                return
-
-            # la recursivite des relations devient recursif-1
-            recursif -= 1
+        if depth >= 0:
+            recursif = True
+            depth -= 1
 
         if columns:
             fprops = list(filter(lambda d: d[0] in columns, cls_db_columns))
@@ -115,21 +112,41 @@ def serializable(cls):
         out = {item: _serializer(getattr(self, item))
                for item, _serializer in fprops}
 
-        if (is_integer and recursif < 0 ) or ( not is_integer and not recursif):
+        if (depth and depth < 0) or not recursif:
             return out
 
         for (rel, uselist) in selected_relationship:
             if getattr(self, rel):
                 if uselist is True:
                     out[rel] = [
-                        x.as_dict(recursif, relationships=relationships)
+                        as_dict_check_depth(
+                            x,
+                            recursif=recursif, relationships=relationships, depth=depth
+                        )
+                        # x.as_dict(recursif=recursif, depth=depth,relationships=relationships)
                         for x in getattr(self, rel)
                     ]
                 else:
-                    out[rel] = getattr(self, rel).as_dict(
-                        recursif, relationships=relationships)
+                    out[rel] = as_dict_check_depth(
+                        getattr(self, rel),
+                        recursif=recursif, relationships=relationships, depth=depth
+                    )
+                    # out[rel] = getattr(self, rel).as_dict(
+                        # recursif=recursif, depth=depth, relationships=relationships)
 
         return out
+
+    # Patch pour les cas ou le paramètre depth n'est pas defini dans as_dict d'un element enfant
+    def as_dict_check_depth(elem, recursif=False, columns=(), relationships=(), depth=None):
+
+        if 'depth' in inspect.getfullargspec(elem.as_dict)[0]:
+            return elem.as_dict(
+                recursif=recursif, columns=columns, relationships=relationships, depth=depth
+                )
+        else:
+            return elem.as_dict(
+                recursif=recursif, columns=columns, relationships=relationships
+                )
 
     def populatefn(self, dict_in):
         '''

--- a/src/utils_flask_sqla/serializers.py
+++ b/src/utils_flask_sqla/serializers.py
@@ -93,9 +93,9 @@ def serializable(cls):
 
         # si recursif est un entier
         #
-        isInteger = type(recursif) == type(1)
+        is_integer = not isinstance(recursif, bool) and isinstance(recursif, int)
 
-        if isInteger:
+        if is_integer:
             if recursif < 0:
                 return
 
@@ -115,7 +115,7 @@ def serializable(cls):
         out = {item: _serializer(getattr(self, item))
                for item, _serializer in fprops}
 
-        if (isInteger and recursif < 0 ) or ( not isInteger and not recursif):
+        if (is_integer and recursif < 0 ) or ( not is_integer and not recursif):
             return out
 
         for (rel, uselist) in selected_relationship:

--- a/src/utils_flask_sqla/serializers.py
+++ b/src/utils_flask_sqla/serializers.py
@@ -93,7 +93,9 @@ def serializable(cls):
 
         # si recursif est un entier
         #
-        if type(recursif) == type(1):
+        isInteger = type(recursif) == type(1)
+
+        if isInteger:
             if recursif < 0:
                 return
 
@@ -113,7 +115,7 @@ def serializable(cls):
         out = {item: _serializer(getattr(self, item))
                for item, _serializer in fprops}
 
-        if not recursif or recursif < 0:
+        if (isInteger and recursif < 0 ) or ( not isInteger and not recursif):
             return out
 
         for (rel, uselist) in selected_relationship:

--- a/src/utils_flask_sqla/serializers.py
+++ b/src/utils_flask_sqla/serializers.py
@@ -95,7 +95,7 @@ def serializable(cls):
                 liste des relationships qui doivent être prise en compte
         """
 
-        if depth >= 0:
+        if isinstance(depth, int) and depth >= 0:
             recursif = True
             depth -= 1
 

--- a/src/utils_flask_sqla/serializers.py
+++ b/src/utils_flask_sqla/serializers.py
@@ -77,14 +77,29 @@ def serializable(cls):
 
         Parameters
         ----------
-            recursif: boolean
-                Spécifie si on veut que les sous objet (relationship)
-                soit également sérialisé
+            recursif: boolean ou entier
+                si boolean:
+                    Spécifie si on veut que les sous-objets (relationship)
+                    soit également sérialisé
+                si entier niveau de récursion:
+                    0 juste l'objet
+                    1 l'objet et ses sous-objets
+                    2 ...
             columns: liste
                 liste des colonnes qui doivent être prises en compte
             relationships: liste
                 liste des relationships qui doivent être prise en compte
         """
+
+        # si recursif est un entier
+        #
+        if type(recursif) == type(1):
+            if recursif < 0:
+                return
+
+            # la recursivite des relations devient recursif-1
+            recursif -= 1
+
         if columns:
             fprops = list(filter(lambda d: d[0] in columns, cls_db_columns))
         else:
@@ -97,7 +112,8 @@ def serializable(cls):
             selected_relationship = cls_db_relationships
         out = {item: _serializer(getattr(self, item))
                for item, _serializer in fprops}
-        if recursif is False:
+
+        if not recursif or recursif < 0:
             return out
 
         for (rel, uselist) in selected_relationship:

--- a/src/utils_flask_sqla/serializers.py
+++ b/src/utils_flask_sqla/serializers.py
@@ -119,34 +119,14 @@ def serializable(cls):
             if getattr(self, rel):
                 if uselist is True:
                     out[rel] = [
-                        as_dict_check_depth(
-                            x,
-                            recursif=recursif, relationships=relationships, depth=depth
-                        )
-                        # x.as_dict(recursif=recursif, depth=depth,relationships=relationships)
+                        x.as_dict(recursif=recursif, depth=depth,relationships=relationships)
                         for x in getattr(self, rel)
                     ]
                 else:
-                    out[rel] = as_dict_check_depth(
-                        getattr(self, rel),
-                        recursif=recursif, relationships=relationships, depth=depth
-                    )
-                    # out[rel] = getattr(self, rel).as_dict(
-                        # recursif=recursif, depth=depth, relationships=relationships)
+                    out[rel] = getattr(self, rel).as_dict(
+                        recursif=recursif, depth=depth, relationships=relationships)
 
         return out
-
-    # Patch pour les cas ou le paramètre depth n'est pas defini dans as_dict d'un element enfant
-    def as_dict_check_depth(elem, recursif=False, columns=(), relationships=(), depth=None):
-
-        if 'depth' in inspect.getfullargspec(elem.as_dict)[0]:
-            return elem.as_dict(
-                recursif=recursif, columns=columns, relationships=relationships, depth=depth
-                )
-        else:
-            return elem.as_dict(
-                recursif=recursif, columns=columns, relationships=relationships
-                )
 
     def populatefn(self, dict_in):
         '''


### PR DESCRIPTION
Suite à un pb de `maximum recursion depth exceeded` avec `as_dict`, j'ai rajouté la possibilité de renseigner le parametre `recursif` comme un entier pour définir le niveau de récursion.

Valeur de `recursif`:
* 0 : juste l'objet équivalent à `False`
* 1 : l'objet et ses sous-objets
* 2 : ...
* ...
* `True` est équivalent à un niveau récursion infini
