### PR TITLE
heritage

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@
 * Ajout de l'instance sqlalchemy (DB) en paramètre de GenericQuery
 * Ajout des exceptions GeonatureApiError
 * Ajout d'une methode from_dict
+* Prise en compte des colonnes redefinies dans le cas d'un heritage
 
 0.0.1 (2019-10-17)
 ------------------

--- a/src/utils_flask_sqla/serializers.py
+++ b/src/utils_flask_sqla/serializers.py
@@ -29,8 +29,10 @@ def serializable(cls):
     """
     cls_db_columns = []
     for prop in cls.__mapper__.column_attrs:
-        if isinstance(prop, ColumnProperty) and len(prop.columns) == 1:
-            db_col = prop.columns[0]
+        if isinstance(prop, ColumnProperty): # and len(prop.columns) == 1:
+            # -1 : si on est dans le cas d'un heritage on recupere le dernier element de prop
+            # qui correspond à la derniere redefinition de cette colonne
+            db_col = prop.columns[-1]
             # HACK
             #  -> Récupération du nom de l'attribut sans la classe
             name = str(prop).split('.', 1)[1]


### PR DESCRIPTION
```
   for prop in cls.__mapper__.column_attrs:
        if isinstance(prop, ColumnProperty): # and len(prop.columns) == 1:
            # -1 : si on est dans le cas d'un heritage on recupere le dernier element de prop
            # qui correspond à la derniere redefinition de cette colonne
            db_col = prop.columns[-1]
```

Dans le cas d'un héritage avec sqlalchemy
on redefini au moins la colonne qui sert de clé primaire de la classe mere en colonne qui sert de cle primaire et étrangère pour la classe fille.

dans ce cas  `len(prop.column) ` vaut 2 et le serializer ne renvoie pas cette colonne

Je propose une modification pour pouvoir récuperer la colonne redéfinie par la classe fille 

```
   for prop in cls.__mapper__.column_attrs:
        if isinstance(prop, ColumnProperty): # and len(prop.columns) == 1:
            # -1 : si on est dans le cas d'un heritage on recupere le dernier element de prop
            # qui correspond à la derniere redefinition de cette colonne
            db_col = prop.columns[-1]
```
