### PR TITLE
temporary transaction at all scope

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,0 @@
-from utils_flask_sqla import serializers

--- a/src/utils_flask_sqla/tests/fixtures.py
+++ b/src/utils_flask_sqla/tests/fixtures.py
@@ -97,6 +97,10 @@ def temporary_function_transaction(request):
     # This is particularly important to test raiseload loading strategy.
     _session.expire_all()
 
+    # Ensure an empty session cache before each test
+    # This is particularly important to test raiseload loading strategy.
+    _session.expire_all()
+
     outer_transaction = _session.begin_nested()
     inner_transaction = _session.begin_nested()
 

--- a/src/utils_flask_sqla/tests/fixtures.py
+++ b/src/utils_flask_sqla/tests/fixtures.py
@@ -2,19 +2,101 @@ import pytest
 from sqlalchemy.event import listen, remove
 
 
-@pytest.fixture(scope="function")
-def temporary_transaction(_session):
-    """
-    We start two nested transaction (SAVEPOINT):
-        - The outer one will be used to rollback all changes made by the current test function.
-        - The inner one will be used to catch all commit() / rollback() made in tested code.
-          After starting the inner transaction, we install a listener on transaction end events,
-          and each time the inner transaction is closed, we restart a new transaction to catch
-          potential new commit() / rollback().
-    Note: When we rollback the inner transaction at the end of the test, we actually rollback
-    only the last inner transaction but previous inner transaction may have been committed by the
-    tested code! This is why we need an outer transaction to rollback all changes made by the test.
-    """
+"""
+We open a nested transaction at each scope, and this nested transaction is rollback at teardown,
+removing all db changes introduced by fixtures at this level.
+
+Changes made by fixtures should be commited to be visible by testing function, but a commit will
+close the nested transaction created for rollback. DO NOT USE db.session.commit() INSIDE FIXTURES!
+Instead, in your fixtures, create a dedicated nested transaction:
+    with db.session.begin_nested():
+        # do changes to database
+    # there, changes are visible, and the parent transation remain open
+
+At function scope level, and only at function scope level, we have a mechanism to detect calls to
+commit() and automatically restart a nested transaction, allowing to keep an outer transaction
+always open until the end of the test, where then all changes are rollback.
+This mechanism is in place at function scope level in order to handle commit() in tested code. But
+it is not available at other scopes, so, as stated before, do not use commit() in your fixtures
+(including function scoped fixtures in order to avoid mistakes, although it may work
+theoretically).
+
+The temporary transaction fixtures must be called before regular fixtures to be able to rollback
+database changes. Decorator @pytest.usefixtures() add fixtures at the end of required fixtures
+list, which does not comply with our needs. Instead, temporary transaction fixtures are marked for
+autouse, ensuring to be executed before other regular fixtures as stated in pytest doc.
+
+As these fixtures are marked for autouse, they are called even in tests which does not interact
+with the database, and worse, in test in which the database is not available. For this reason,
+these fixture check that the "_session" fixture is part of the test requested fixtures. It is
+therefore necessary that any test interacting with the db requires the "_session" fixture.
+"""
+
+
+@pytest.fixture(scope="session", autouse=True)
+def temporary_session_transaction(request):
+    try:
+        _session = request.getfixturevalue("_session")
+    except pytest.FixtureLookupError:
+        yield
+        return
+
+    transaction = _session.begin_nested()
+    yield transaction
+    transaction.rollback()
+
+
+@pytest.fixture(scope="package", autouse=True)
+def temporary_package_transaction(request):
+    try:
+        _session = request.getfixturevalue("_session")
+    except pytest.FixtureLookupError:
+        yield
+        return
+
+    transaction = _session.begin_nested()
+    yield transaction
+    transaction.rollback()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def temporary_module_transaction(request):
+    try:
+        _session = request.getfixturevalue("_session")
+    except pytest.FixtureLookupError:
+        yield
+        return
+
+    transaction = _session.begin_nested()
+    yield transaction
+    transaction.rollback()
+
+
+@pytest.fixture(scope="class", autouse=True)
+def temporary_class_transaction(request):
+    try:
+        _session = request.getfixturevalue("_session")
+    except pytest.FixtureLookupError:
+        yield
+        return
+
+    transaction = _session.begin_nested()
+    yield transaction
+    transaction.rollback()
+
+
+@pytest.fixture(scope="function", autouse=True)
+def temporary_function_transaction(request):
+    try:
+        _session = request.getfixturevalue("_session")
+    except pytest.FixtureLookupError:
+        yield
+        return
+
+    # Ensure an empty session cache before each test
+    # This is particularly important to test raiseload loading strategy.
+    _session.expire_all()
+
     outer_transaction = _session.begin_nested()
     inner_transaction = _session.begin_nested()
 
@@ -26,9 +108,15 @@ def temporary_transaction(_session):
 
     listen(_session, "after_transaction_end", restart_savepoint)
 
-    yield
+    yield outer_transaction
 
     remove(_session, "after_transaction_end", restart_savepoint)
 
     inner_transaction.rollback()  # probably rollback not so much
     outer_transaction.rollback()  # rollback all changes made during this test
+
+
+# retro-compatibility, should be deleted
+@pytest.fixture
+def temporary_transaction():
+    yield

--- a/src/utils_flask_sqla/tests/plugin.py
+++ b/src/utils_flask_sqla/tests/plugin.py
@@ -1,1 +1,8 @@
-from .fixtures import temporary_transaction
+from .fixtures import (
+    temporary_session_transaction,
+    temporary_package_transaction,
+    temporary_module_transaction,
+    temporary_class_transaction,
+    temporary_function_transaction,
+    temporary_transaction,
+)

--- a/src/utils_flask_sqla/tests/test_temporary_transaction.py
+++ b/src/utils_flask_sqla/tests/test_temporary_transaction.py
@@ -1,0 +1,120 @@
+from tempfile import NamedTemporaryFile
+
+import pytest
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+
+
+db = SQLAlchemy()
+
+
+class MyModel(db.Model):
+    pk = db.Column(db.Integer, primary_key=True)
+    instance = db.Column(db.Integer)
+
+
+@pytest.fixture(scope="session")
+def _app():
+    app = Flask(__name__)
+    sqlite = NamedTemporaryFile()
+    app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{sqlite.name}"
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+        yield
+
+
+@pytest.fixture(scope="session")
+def _session(_app):
+    return db.session
+
+
+@pytest.fixture(scope="session")
+def app(_app, _session):
+    pass
+
+
+@pytest.fixture(
+    scope="session",
+)
+def fixture_session(app):
+    o = MyModel(pk=1)
+    with db.session.begin_nested():
+        db.session.add(o)
+
+
+@pytest.fixture(scope="class")
+def fixture_class1(app):
+    o = MyModel(pk=2, instance=1)
+    with db.session.begin_nested():
+        db.session.add(o)
+
+
+@pytest.fixture(scope="class")
+def fixture_class2(app):
+    # should not conflict with fixture_class1 if correctly rollback
+    o = MyModel(pk=2, instance=2)
+    with db.session.begin_nested():
+        db.session.add(o)
+
+
+@pytest.fixture(scope="function")
+def fixture_function1(app):
+    o = MyModel(pk=3)
+    db.session.add(o)
+    db.session.commit()
+
+
+@pytest.fixture(scope="function")
+def fixture_function2(app):
+    # should not conflict with fixture_function1 if correctly rollback
+    o = MyModel(pk=3)
+    db.session.add(o)
+    db.session.commit()
+
+
+class TestTemporaryTransaction:
+    def test_temporary_transactions(
+        self,
+        app,
+        temporary_session_transaction,
+        temporary_package_transaction,
+        temporary_module_transaction,
+        temporary_class_transaction,
+        temporary_function_transaction,
+    ):
+        transaction = db.session.begin_nested()
+        transaction = transaction.parent  # inner function-scoped transaction
+        transaction = transaction.parent  # outer function-scoped transaction
+        assert transaction == temporary_function_transaction
+        transaction = transaction.parent  # class-scoped transaction
+        assert transaction == temporary_class_transaction
+        transaction = transaction.parent  # module-scoped transaction
+        assert transaction == temporary_module_transaction
+        # Here, _session is defined in this module, which guarentees that module-scoped
+        # temporary transaction will be created. But package-scoped and session-scoped
+        # transaction fixtures may be initialized from another module, where _session
+        # does not exists. If so, these fixtures will be null. But you are not likely
+        # to use package-scoped fixture using the database if the session is defined
+        # at module level…
+        # transaction = transaction.parent  # package-scoped transaction
+        # assert transaction == temporary_package_transaction
+        # transaction = transaction.parent  # session-scoped transaction
+        # assert transaction == temporary_session_transaction
+
+
+@pytest.mark.usefixtures("temporary_transaction")  # to test retro-compat
+class TestClassOne:
+    def test_c1_f1(self, app, fixture_session, fixture_class1, fixture_function1):
+        pass
+
+    def test_c1_f2(self, app, fixture_session, fixture_class1, fixture_function2):
+        pass
+
+
+class TestClassTwo:
+    def test_c2_f1(self, app, fixture_session, fixture_class2, fixture_function1):
+        pass
+
+    def test_c2_f2(self, app, fixture_session, fixture_class2, fixture_function2):
+        pass


### PR DESCRIPTION
Les explications technique se trouvent en commentaires dans le fichier `fixtures.py`

Voir également https://github.com/PnX-SI/GeoNature/pull/3458 pour l’usage.