### PR TITLE
GenericQuery: fix bug negative limit

### DIFF
--- a/src/utils_flask_sqla/generic.py
+++ b/src/utils_flask_sqla/generic.py
@@ -164,11 +164,11 @@ class GenericQuery:
     def __init__(
         self,
         DB,
-        tableName:str,
-        schemaName:str,
-        filters:list=[],
-        limit:int=None,
-        offset:int=0,
+        tableName: str,
+        schemaName: str,
+        filters: list = [],
+        limit: int = None,
+        offset: int = 0,
     ):
         self.DB = DB
         self.tableName = tableName

--- a/src/utils_flask_sqla/generic.py
+++ b/src/utils_flask_sqla/generic.py
@@ -164,16 +164,18 @@ class GenericQuery:
     def __init__(
         self,
         DB,
-        tableName,
-        schemaName,
-        filters=[],
-        limit=100,
-        offset=0,
+        tableName:str,
+        schemaName:str,
+        filters:list=[],
+        limit:int=None,
+        offset:int=0,
     ):
         self.DB = DB
         self.tableName = tableName
         self.schemaName = schemaName
         self.filters = filters
+        if limit:
+            assert limit > 0
         self.limit = limit
         self.offset = offset
         self.view = GenericTable(tableName, schemaName, DB.engine)
@@ -254,7 +256,7 @@ class GenericQuery:
             unordered_q = self.build_query_filters(q, self.filters)
             q = self.build_query_order(unordered_q, self.filters)
 
-        if self.limit != -1:
+        if self.limit:
             q = self.set_limit(q)
 
         return q

--- a/src/utils_flask_sqla/generic.py
+++ b/src/utils_flask_sqla/generic.py
@@ -240,11 +240,10 @@ class GenericQuery:
     def set_limit(self, q):
         return q.limit(self.limit).offset(self.offset * self.limit)
 
-    def raw_query(self, process_filter=True, with_limit=True):
+    def raw_query(self, process_filter=True):
         """
         Renvoie la requete 'brute' (sans .all)
         - process_filter: application des filtres (et du sort)
-        - with_limit: application de la limite sur la query
         """
 
         q = self.DB.session.query(self.view.tableDef)
@@ -255,7 +254,7 @@ class GenericQuery:
             unordered_q = self.build_query_filters(q, self.filters)
             q = self.build_query_order(unordered_q, self.filters)
 
-        if self.limit != -1 and with_limit:
+        if self.limit != -1:
             q = self.set_limit(q)
 
         return q
@@ -267,10 +266,10 @@ class GenericQuery:
         q = self.DB.session.query(self.view.tableDef)
         nb_result_without_filter = q.count()
 
-        q = self.raw_query(process_filter=True, with_limit=False)
+        q = self.raw_query(process_filter=True)
         total_filtered = q.count() if self.filters else nb_result_without_filter
 
-        data = self.set_limit(q).all()
+        data = q.all()
 
         return data, nb_result_without_filter, total_filtered
 


### PR DESCRIPTION
Il me semble qu'il y a un bug entre la version 0.3.3 et la version 0.4.1 quand on utilise limit=-1 dans la GenericQuery : 
{"code": 500, "description": "(psycopg2.errors.InvalidRowCountInLimitClause) LIMIT must not be negative}

J'ai ce bug quand je clique sur le bouton 'générer la liste des espèces' (qui utilise Generic Query) dans le module zones humides (onglet 5) lorsque la version de Utils-Flask-SQLAlchemy est 0.4.1 mais pas lorsque qu'elle est en 0.3.3. 

Voici une proposition de correction avec suppression de l'argument with_limit. J'ai peut-être manqué quelque chose mais je ne comprends pas vraiment en quoi cet argument est utile ? Si limit=-1 de toute façon il n'y a pas de limite et sinon on renseigne la limite souhaitée. 