### PR TITLE
feat(SmartRelationshipsMixin): support "-" in only

### DIFF
--- a/src/utils_flask_sqla/tests/test_schema.py
+++ b/src/utils_flask_sqla/tests/test_schema.py
@@ -216,6 +216,17 @@ class TestSmartRelationshipsMixin:
             {"pk": 1, "col": None, "parent_pk": None, "parent": None, "address_pk": None},
         )
 
+    def test_no_firstlevel_fields(self):
+        child = Child(pk=1)
+        parent = Parent(pk=1, childs=[child])
+
+        TestCase().assertDictEqual(
+            ParentSchema(only=("-", "childs.pk")).dump(parent),
+            {
+                "childs": [{"pk": 1}],
+            },
+        )
+
     def test_polymorphic_model(self):
         class PolyModel(db.Model):
             __mapper_args__ = {


### PR DESCRIPTION
Add "-" special value to only to remove all default fields from serialization when you want to serialize only relationships.