### PR TITLE
add db.ordered utility

### DIFF
--- a/src/utils_flask_sqla/db.py
+++ b/src/utils_flask_sqla/db.py
@@ -29,7 +29,7 @@ def get_column_from_path(select, model, path, *, join=False):
         return select, col
 
 
-def ordered(select, model, *, order_by=None, join=False, arg_name="sort"):
+def ordered(select, model, *, order_by=None, join=False, arg_name="sort", reset=False):
     """
     User can order the select query through 'sort' query parameter.
     Several order criterias can be applied separating them with commas.
@@ -40,6 +40,7 @@ def ordered(select, model, *, order_by=None, join=False, arg_name="sort"):
     of the query, a BadRequest is raised.
     The order_by argument allow to specify a default ordering if no order is requested
     in the query.
+    If reset=True, existing order by criterias are cancelled before applying those of users.
     """
     sort = request.args.get(arg_name)
     if sort:
@@ -63,6 +64,8 @@ def ordered(select, model, *, order_by=None, join=False, arg_name="sort"):
                 col = col.asc()
 
             order_by.append(col)
+        if reset:
+            select = select.order_by(None)
         return select.order_by(*order_by)
     elif order_by is not None:
         if isinstance(order_by, list) or isinstance(order_by, tuple):

--- a/src/utils_flask_sqla/db.py
+++ b/src/utils_flask_sqla/db.py
@@ -1,0 +1,72 @@
+from flask import request
+from werkzeug.exceptions import BadRequest
+
+
+__all__ = ["ordered"]
+
+
+def get_column_from_path(select, model, path, *, join=False):
+    """
+    Return a tuple (select, column), with column retrieved from the model following the given path.
+    If join is True, each time a relationship is traversed, the related model is automatically
+    joined to the select statement.
+    """
+    field, _, path = path.partition(".")
+    if path:
+        try:
+            rel = model.__mapper__.relationships[field]
+        except KeyError:
+            raise BadRequest("{} does not have a relationship '{}'".format(model, field))
+        if join:
+            select = select.join(getattr(model, field))
+        model = rel.mapper.class_
+        return get_column_from_path(select, model, path, join=join)
+    else:
+        try:
+            col = model.__mapper__.columns[field]
+        except KeyError:
+            raise BadRequest("{} does not have a field '{}'".format(model, field))
+        return select, col
+
+
+def ordered(select, model, *, order_by=None, join=False):
+    """
+    User can order the select query through 'sort' query parameter.
+    Several order criterias can be applied separating them with commas.
+    Each criteria can be descending by prefixing it by '-'.
+    Criteria can refer to a relationship using the dot notation.
+    However, related model must be joined to the query, which can be done automatically
+    with join=True. If join=False and referenced related model is not part of from clause
+    of the query, a BadRequest is raised.
+    The order_by argument allow to specify a default ordering if no order is requested
+    in the query.
+    """
+    sort = request.args.get("sort")
+    if sort:
+        order_by = []
+        sort = sort.split(",")
+        for path in sort:
+            direction = None
+            if path.startswith("-"):
+                path = path[1:]
+                direction = "desc"
+
+            select, col = get_column_from_path(select, model, path, join=join)
+            if not join and not any(
+                [col in from_clause.columns.values() for from_clause in select.get_final_froms()]
+            ):
+                raise BadRequest("{} is not part of from clauses".format(path))
+
+            if direction == "desc":
+                col = col.desc()
+            else:
+                col = col.asc()
+
+            order_by.append(col)
+        return select.order_by(*order_by)
+    elif order_by is not None:
+        if isinstance(order_by, list) or isinstance(order_by, tuple):
+            return select.order_by(*order_by)
+        else:
+            return select.order_by(order_by)
+    return select

--- a/src/utils_flask_sqla/db.py
+++ b/src/utils_flask_sqla/db.py
@@ -29,7 +29,7 @@ def get_column_from_path(select, model, path, *, join=False):
         return select, col
 
 
-def ordered(select, model, *, order_by=None, join=False):
+def ordered(select, model, *, order_by=None, join=False, arg_name="sort"):
     """
     User can order the select query through 'sort' query parameter.
     Several order criterias can be applied separating them with commas.
@@ -41,7 +41,7 @@ def ordered(select, model, *, order_by=None, join=False):
     The order_by argument allow to specify a default ordering if no order is requested
     in the query.
     """
-    sort = request.args.get("sort")
+    sort = request.args.get(arg_name)
     if sort:
         order_by = []
         sort = sort.split(",")

--- a/src/utils_flask_sqla/db.py
+++ b/src/utils_flask_sqla/db.py
@@ -31,22 +31,96 @@ def get_column_from_path(select, model, path, *, join=False):
 
 def ordered(select, model, *, order_by=None, join=False, arg_name="sort", reset=False):
     """
-    User can order the select query through 'sort' query parameter.
-    Several order criterias can be applied separating them with commas.
-    Each criteria can be descending by prefixing it by '-'.
+    This method applies an order_by on query based on column(s) found either in the
+    query parameters or directly in the function parameter `order_by`.
+
+    Usage
+    =====
+
+    Using query parameters
+    ----------------------
+
+    To fetch column using the query, indicate the query parameter name in the
+    `arg_name` function parameter.
+
+    Example 1: Fetch column by query parameter
+
+    >>> ## URL of the query : http://localhost/api/route?sort=name
+    >>> ordered(select,User,arg_name=sort)
+
+    Example 2: Fetch multiple columns by query parameter
+
+    >>> ## URL of the query : http://localhost/api/route?sort=name,address
+    >>> ordered(select,User,arg_name=sort)
+
+    Example 3: Change ordering direction by prefixing each field name with a
+    `-`
+
+    >>> ## URL of the query : http://localhost/api/route?sort=-name,address
+    >>> ordered(select,User,arg_name=sort)
+
+    Using `order_by` function parameter
+    -----------------------------------
+
+    Simply, indicate the column object in the `order_by` parameter
+
+    Example 1: Order by a single column
+
+    >>>  ordered(select,User,order_by=User.name)
+
+    Example 2: Order by multiple columns with different directions
+
+    >>>  ordered(select,User,order_by=[User.name.desc(), User.address])
+
+    Cancel previous ordering
+    ========================
+
+    Set the `reset` parameter to True to deactivate previous order_by on the
+    existing query.
+
+    Example: Reset previous ordering
+
+    >>>  ordered(select,User,reset=True)
+
+    `join` parameter
+    ================
+
     Criteria can refer to a relationship using the dot notation.
     However, related model must be joined to the query, which can be done automatically
     with join=True. If join=False and referenced related model is not part of from clause
     of the query, a BadRequest is raised.
-    The order_by argument allow to specify a default ordering if no order is requested
-    in the query.
-    If reset=True, existing order by criterias are cancelled before applying those of users.
+
+    Parameters
+    ==========
+    select : Union[Select, Selectable]
+        A SQLAlchemy select statement
+    model : Model
+        The model class for which the ordering should be performed.
+    order_by : Optional[Union[str, List[str], Tuple[str]]]
+        A string or a list/tuple of strings representing the columns to order
+    by. If `None`, the default ordering will be used.
+    join : bool, optional
+        Whether to perform a join with the `model` table before applying the
+    ordering. Defaults to `False`.
+    arg_name : str, optional
+        The name of the query parameter that contains the sorting information.
+    Defaults to `"sort"`.
+    reset : bool, optional
+        Whether to reset the existing ordering before applying the new ordering.
+    Defaults to `False`.
+
+    Returns
+    =======
+    Union[Select, Selectable]
+        A SQLAlchemy select statement or an object that can be passed to
+    `sqlalchemy.orm.class_mapper` with the applied ordering.
     """
-    sort = request.args.get(arg_name)
-    if sort:
+
+    sort_fields = request.args.get(arg_name)
+    if sort_fields:
         order_by = []
-        sort = sort.split(",")
-        for path in sort:
+        sort_fields = sort_fields.split(",")
+        for path in sort_fields:
             direction = None
             if path.startswith("-"):
                 path = path[1:]
@@ -67,9 +141,13 @@ def ordered(select, model, *, order_by=None, join=False, arg_name="sort", reset=
         if reset:
             select = select.order_by(None)
         return select.order_by(*order_by)
+
     elif order_by is not None:
+        if reset:
+            select = select.order_by(None)
         if isinstance(order_by, list) or isinstance(order_by, tuple):
             return select.order_by(*order_by)
         else:
             return select.order_by(order_by)
+
     return select

--- a/src/utils_flask_sqla/tests/test_ordered.py
+++ b/src/utils_flask_sqla/tests/test_ordered.py
@@ -103,6 +103,21 @@ class TestOrdered:
             for o1, o2 in pairwise(results):
                 assert o1.pk > o2.pk
 
+    def test_ordered_column_arg_name(self, app):
+        query = sa.select(Parent)
+
+        with app.test_request_context("?orderby=pk"):
+            stmt = ordered(query, Parent, arg_name="orderby")
+            results = db.session.execute(stmt).scalars()
+            for o1, o2 in pairwise(results):
+                assert o1.pk < o2.pk
+
+        with app.test_request_context("?orderby=-pk"):
+            stmt = ordered(query, Parent, arg_name="orderby")
+            results = db.session.execute(stmt).scalars()
+            for o1, o2 in pairwise(results):
+                assert o1.pk > o2.pk
+
     def test_ordered_relationship_not_joined(self, app):
         query = sa.select(Child)
 

--- a/src/utils_flask_sqla/tests/test_ordered.py
+++ b/src/utils_flask_sqla/tests/test_ordered.py
@@ -1,0 +1,175 @@
+import sys
+
+if sys.version_info < (3, 10):
+
+    def pairwise(iterable):
+        # pairwise('ABCDEFG') → AB BC CD DE EF FG
+
+        iterator = iter(iterable)
+        a = next(iterator, None)
+
+        for b in iterator:
+            yield a, b
+            a = b
+
+else:
+    from itertools import pairwise
+
+
+import pytest
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+import sqlalchemy as sa
+from werkzeug.exceptions import BadRequest
+
+from utils_flask_sqla.db import ordered
+
+
+db = SQLAlchemy()
+
+
+class Parent(db.Model):
+    pk = db.Column(db.Integer, primary_key=True)
+
+
+class Child(db.Model):
+    pk = db.Column(db.Integer, primary_key=True)
+    parent_pk = db.Column(db.Integer, db.ForeignKey(Parent.pk))
+    parent = db.relationship("Parent", backref="childs")
+
+
+@pytest.fixture(scope="session")
+def app():
+    app = Flask("utils-flask-sqla")
+    app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///"
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+        yield app
+
+
+@pytest.fixture(scope="class")
+def data(app):
+    p1 = Parent(pk=1)
+    p2 = Parent(pk=2)
+    c1 = Child(pk=1, parent_pk=1)
+    c2 = Child(pk=2, parent_pk=2)
+    c3 = Child(pk=3, parent_pk=1)
+    c4 = Child(pk=4, parent_pk=2)
+    with db.session.begin_nested():
+        db.session.add_all([p1, p2, c1, c2, c3, c4])
+
+
+@pytest.mark.usefixtures("data")
+class TestOrdered:
+    def test_no_ordering(self, app):
+        query = sa.select(Parent)
+
+        with app.test_request_context():
+            stmt = ordered(query, Parent)
+            results = db.session.execute(stmt).scalars()
+
+    def test_ordered_default(self, app):
+        query = sa.select(Parent)
+
+        with app.test_request_context():
+            stmt = ordered(query, Parent, order_by="pk")
+            results = db.session.execute(stmt).scalars()
+            for o1, o2 in pairwise(results):
+                assert o1.pk < o2.pk
+
+            stmt = ordered(query, Parent, order_by=Parent.pk.desc())
+            results = db.session.execute(stmt).scalars()
+            for o1, o2 in pairwise(results):
+                assert o1.pk > o2.pk
+
+            stmt = ordered(query, Parent, order_by=[Parent.pk.asc()])
+            results = db.session.execute(stmt).scalars()
+            for o1, o2 in pairwise(results):
+                assert o1.pk < o2.pk
+
+    def test_ordered_column(self, app):
+        query = sa.select(Parent)
+
+        with app.test_request_context("?sort=pk"):
+            stmt = ordered(query, Parent)
+            results = db.session.execute(stmt).scalars()
+            for o1, o2 in pairwise(results):
+                assert o1.pk < o2.pk
+
+        with app.test_request_context("?sort=-pk"):
+            stmt = ordered(query, Parent)
+            results = db.session.execute(stmt).scalars()
+            for o1, o2 in pairwise(results):
+                assert o1.pk > o2.pk
+
+    def test_ordered_relationship_not_joined(self, app):
+        query = sa.select(Child)
+
+        with app.test_request_context("?sort=parent.pk"):
+            with pytest.raises(BadRequest, match=".*not part of from clauses.*"):
+                stmt = ordered(query, Child)
+
+    def test_ordered_relationship_manually_joined(self, app):
+        query = sa.select(Child).join(Parent)
+
+        with app.test_request_context("?sort=parent.pk"):
+            stmt = ordered(query, Child)
+            results = db.session.execute(stmt).scalars()
+            for o1, o2 in pairwise(results):
+                assert o1.parent.pk <= o2.parent.pk
+
+        with app.test_request_context("?sort=-parent.pk"):
+            stmt = ordered(query, Child)
+            results = db.session.execute(stmt).scalars()
+            for o1, o2 in pairwise(results):
+                assert o1.parent.pk >= o2.parent.pk
+
+    def test_ordered_relationship_auto_joined(self, app):
+        query = sa.select(Child)
+
+        with app.test_request_context("?sort=parent.pk"):
+            stmt = ordered(query, Child, join=True)
+            results = db.session.execute(stmt).scalars()
+            for o1, o2 in pairwise(results):
+                assert o1.parent.pk <= o2.parent.pk
+
+        with app.test_request_context("?sort=-parent.pk"):
+            stmt = ordered(query, Child, join=True)
+            results = db.session.execute(stmt).scalars()
+            for o1, o2 in pairwise(results):
+                assert o1.parent.pk >= o2.parent.pk
+
+    def test_ordered_multiple_criterias(self, app):
+        query = sa.select(Child)
+
+        with app.test_request_context("?sort=parent.pk,pk"):
+            stmt = ordered(query, Child, join=True)
+            results = db.session.execute(stmt).scalars()
+            for o1, o2 in pairwise(results):
+                assert o1.parent.pk <= o2.parent.pk
+                if o1.parent.pk == o2.parent.pk:
+                    assert o1.pk < o2.pk
+
+        with app.test_request_context("?sort=parent.pk,-pk"):
+            stmt = ordered(query, Child, join=True)
+            results = db.session.execute(stmt).scalars()
+            for o1, o2 in pairwise(results):
+                assert o1.parent.pk <= o2.parent.pk
+                if o1.parent.pk == o2.parent.pk:
+                    assert o1.pk > o2.pk
+
+    def test_ordered_unexisting_criterias(self, app):
+        query = sa.select(Child)
+
+        with app.test_request_context("?sort=unexisting"):
+            with pytest.raises(BadRequest, match=".*does not have.*"):
+                stmt = ordered(query, Child, join=True)
+
+        with app.test_request_context("?sort=unexisting.pk"):
+            with pytest.raises(BadRequest, match=".*does not have.*"):
+                stmt = ordered(query, Child, join=True)
+
+        with app.test_request_context("?sort=parent.unexisting"):
+            with pytest.raises(BadRequest, match=".*does not have.*"):
+                stmt = ordered(query, Child, join=True)


### PR DESCRIPTION
Ajout d’un utilitaire `db.ordered` pour ne plus à avoir à implémenter dans chaque route la possibilité à l’utilisateur de choisir l’ordre des résultats. Regarde le paramètre `sort` de la requête.

Possibilité de filtrer sur plusieurs colonnes, par ordre descendant, sur des relationships.

Pour les relationships, il faut que le modèle en relation soit join à la requête, sans quoi une erreur `BadRequest` est levée. Il est également possible de demander à ce qu’il soit automatiquement joint à la requête.